### PR TITLE
Fix: Improve CSS responsiveness for small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 /* ==========================================================================
    Evitar desbordamiento horizontal globalmente
    ========================================================================== */
@@ -381,12 +385,61 @@
       width: 100%;
       box-sizing: border-box;
     }
+
+    .console code {
+      word-break: break-all;
+    }
+
+    .bar-label {
+      width: 80px;
+      /* Consider adjusting font-size if text still wraps or is too close to edges */
+      /* font-size: 0.85em; */
+    }
   
     /* Ajuste de avatar en móvil */
     .avatar.tall {
-      width: 80px;
-      height: 120px;
+      width: 70px;
+      height: 70px;
       margin-bottom: 10px;
     }
   }
-  
+
+/* ==========================================================================
+   Responsive móvil (pantallas ≤ 480px)
+   ========================================================================== */
+@media (max-width: 480px) {
+  body {
+    padding: 8px;
+  }
+
+  .console {
+    padding: 10px;
+    font-size: 0.85em;
+  }
+
+  .header-text .title {
+    font-size: 1.5em;
+  }
+
+  .header-text .subtitle {
+    font-size: 0.8em;
+  }
+
+  .console h2 {
+    font-size: 1em;
+  }
+
+  .avatar.tall {
+    width: 50px;
+    height: 50px;
+  }
+
+  .lang .bar-label {
+    width: 70px;
+    font-size: 0.9em;
+  }
+
+  .header-left .header-text {
+    margin-left: 10px;
+  }
+}


### PR DESCRIPTION
This commit addresses issues with the website's display on smaller screens, particularly mobile devices.

The following changes were made to style.css:
- Applied `box-sizing: border-box` globally to all elements, ensuring more predictable sizing.
- Adjusted styles within the existing `@media (max-width: 768px)` query:
    - Enabled `word-break: break-all` for `.console code` to prevent long text from overflowing.
    - Reduced the width of `.bar-label` for language bars.
    - Resized the `.avatar.tall` to be square and slightly smaller.
- Introduced a new media query `@media (max-width: 480px)` for very small screens, which includes:
    - Reduced body and console padding.
    - Smaller font sizes for titles, subtitles, and general console text.
    - Further reduction in avatar size.
    - Adjusted width and font size for language bar labels.
    - Reduced left margin for header text to accommodate smaller avatar.

These changes aim to provide a better user experience on devices with narrow viewports, preventing horizontal overflow and improving readability.